### PR TITLE
Show RuboCop and RSpec results in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,15 @@ rspec: &rspec
   steps:
     - checkout
     - run: bundle install
-    - run: rake spec
+    - run:
+        name: rspec
+        command: >
+          rspec
+          --format documentation
+          --format RspecJunitFormatter
+          --out ci-results/RSpec/rspec.xml
+    - store_test_results:
+        path: ci-results
 
 rubocop: &rubocop
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,16 @@ rubocop: &rubocop
   steps:
     - checkout
     - run: bundle install
-    - run: rake internal_investigation
+    - run:
+        name: rubocop
+        command: >
+          rubocop
+          -r $(bundle show rubocop-junit-formatter)/lib/rubocop/formatter/junit_formatter.rb
+          --format progress
+          --format RuboCop::Formatter::JUnitFormatter
+          --out ci-results/RuboCop/rubocop.xml
+    - store_test_results:
+        path: ci-results
 
 jobs:
   confirm_config_and_documentation:

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Gemfile.local
 # jeweler generated
 pkg
 
+/ci-results
 /vendor
 
 .ruby-gemset

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 group :test do
   gem 'simplecov', require: false
   gem 'rspec_junit_formatter'
+  gem 'rubocop-junit-formatter'
 end
 
 local_gemfile = 'Gemfile.local'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :test do
   gem 'simplecov', require: false
+  gem 'rspec_junit_formatter'
 end
 
 local_gemfile = 'Gemfile.local'


### PR DESCRIPTION
Before, Circle CI looked line this:

![before](https://user-images.githubusercontent.com/22333/35124846-dc01498c-fca7-11e7-9de6-9ea976580ccb.png)

Now, it looks like this (for RSpec runs):
![after-rspec](https://user-images.githubusercontent.com/22333/35124842-dbad76fe-fca7-11e7-8400-65139bb1ee5b.png)

For RuboCop runs:

![after-rubocop](https://user-images.githubusercontent.com/22333/35124844-dbe65d02-fca7-11e7-8748-8f642e856e30.png)

And if e.g. RuboCop should happen to fail, it looks like this:

![after-rubocop-failure](https://user-images.githubusercontent.com/22333/35124843-dbc88bce-fca7-11e7-94f4-afe0f4cf6288.png)
